### PR TITLE
Add nodejs convention. Update document structure.

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -1,26 +1,52 @@
-# PDR Javascript Style Guide
+# Introduction
+
+이 문서는 **전반적인 자바스크립트 스타일**에 대해서 말합니다.
+따라서 Server-side, Client-side를 따로 구분하지 않습니다.
+
+# Styles
+
+[Google Style Guide](https://google.github.io/styleguide/javascriptguide.xml)를 따릅니다.
+
+다음은 구글 스타일 가이드에서도 중요한 부분을 다룹니다:
 
 0. 들여쓰기는 탭과 공백 혼합 없이 4-space.
 
-1. File name은 모두 소문자를 사용하고 _ , - 를 사용가능하며 그 외의 기호는 사용하면 안된다.
+0. File name은 모두 소문자를 사용하고 _ , - 를 사용가능하며 그 외의 기호는 사용하면 안된다.
 
-2. {} 사용은 모든 if, else, for, do, while control block 등에 사용한다. 오직 하나의 예외는 ```if (test()) return;``` 과 같이 짧고 return만 있는 경우
+0. {} 사용은 모든 if, else, for, do, while control block 등에 사용한다. 오직 하나의 예외는 ```if (test()) return;``` 과 같이 짧고 return만 있는 경우
 
-3. 모든 statement 뒤에는 semicolon (;) 을 붙인다. 아래와 같이 다른 결과가 나오는 것을 방지 할 수 있다.
+0. 모든 statement 뒤에는 semicolon (;) 을 붙인다. 아래와 같이 다른 결과가 나오는 것을 방지 할 수 있다.
 
-```
-    function foo1()
+```javascript
+// return Object
+function foo1() {
+    return {
+        bar: 'hello'
+    };
+}
+
+// return undefined
+function foo2() {
+    return
     {
-        return {
-            bar: "hello"
-        };
-    }
-
-    function foo2()
-    {
-        return
-        {
-            bar: "hello"
-        };
-    }
+        bar: 'hello'
+    };
+}
 ```
+
+# Comments
+
+주석은 코드를 문서화 도구를 이용해 자동으로 문서화 할 수 있는 중요한 요소입니다.
+
+스타일은 [JSDoc](http://usejsdoc.org/about-getting-started.html)을 따르지만
+[Google Style Guide](https://google.github.io/styleguide/javascriptguide.xml)에
+언급되어 있는 대로 **제한된 Tag**만 사용합니다.
+이에 대해서는 [Google Style Guide - Comments](https://google.github.io/styleguide/javascriptguide.xml?showone=Comments#Comments)
+단락을 확인하시기 바랍니다.
+
+다음은 [Google Style Guide](https://google.github.io/styleguide/javascriptguide.xml)에
+명시적으로 언급되지 않은 부분입니다.
+
+- ```@type```, ```@param``` 등에서의 배열 타입의 표현
+    - ```string[]``` -> ```Array.<string>```
+    - 2차원 배열인 경우: ```[string, number][]``` -> ```Array.<Array.<string, number>>```

--- a/nodejs.md
+++ b/nodejs.md
@@ -1,0 +1,66 @@
+# Introduction
+
+이 문서는 **Node.js를 이용하는 웹 스택 프로젝트**에 대해 설명합니다.
+
+# Restriction
+
+- Web Server Framework로 [Express.js](http://expressjs.com/ko/)를 사용합니다.
+- RESTFul API를 지향합니다.
+
+# Project Architecture
+
+```bash
+src/
+    config/
+    controller/
+    dao/
+    middleware/
+    models/
+    routes/
+    util/
+test/
+.gitginore
+index.js
+package.json
+README.md
+```
+
+- src/
+    - 모든 소스 코드는 이 디렉토리 안에서 작성합니다.
+- src/config/
+    - 시스템 설정에 대한 소스 코드를 저장합니다.
+    - DB Connection 정보. 시스템 실행 환경 등이 포함됩니다.
+- src/controller/
+    - 컨트롤러는 하나의 트랜잭션을 의미합니다.
+    - router와 직접 연결되어 있으며, router에 대한 동작은 컨트롤러에서 합니다.
+    - 오직 컨트롤러만이 Dao를 호출할 수 있습니다.
+- src/dao/
+    - Data Access Object의 약자입니다.
+    - DAO만이 Query를 전송할 수 있습니다.
+    - 쿼리문과 PacketDataRow에 대한 Mapping을 수행합니다.
+    - PacketDataRow는 node-mysql의 데이터 정보를 가진 객체입니다.
+- src/middleware/
+    - express의 middleware입니다.
+    - Session 검사, http header 등 모든 라우터에 공통적으로 하는 일을 수행합니다.
+- src/models/
+    - 시스템 로직을 가진 객체입니다.
+    - OOP에서는 객체들의 관계로 도메인을 주도합니다.
+    - 디자인 패턴으로 나타낼 수 있습니다.
+    디자인 패턴은 알려진 문제를 해결하고 개발자간 커뮤니케이션을 유연하게 할 수 있는 요소입니다.
+- src/routes/
+    - 각 API URL은 여기에 파일로 나타납니다.
+    - API Parameter 유효성을 검사하고 컨트롤러에 넘겨줍니다.
+- src/utils/
+    - 특정 클래스에 종속되지 않는 클래스입니다.
+    - 배열을 특정 크기로 잘라 주거나 맵에서 값으로 키 값을 찾아주는 클래스 등
+    유용한 클래스를 만들 수 있습니다.
+- test/
+    - 테스트 코드는 여기에 작성합니다.
+- index.js
+    - 시스템의 Entry Point입니다.
+- package.json
+    - npm 모듈 의존성 관리 및 프로젝트 정보를 저장하는 파일입니다.
+- README.md
+    - 프로젝트 정보를 나타내는 Markdown 파일입니다.
+    - 간단하게 나마 어떤 일을 하는 프로젝트인지 작성해야 합니다.
+    - 빌드 또는 실행 방법을 설명해야 합니다.


### PR DESCRIPTION
### 문서 구조를 수정하려 합니다.

\# Header 1을 각 문서의 주제의 제목을 의미 했으면 합니다.
현재 구조는 문서 제목을 의미하여 Header 1이 하나만 존재하게 됩니다.
다른 깃허브 프로젝트들을 둘러봤더니 주제 제목으로 Header 1을 사용하는 저장소가 좀 있었습니다.
예를들어 \# 빌드방법, \# 소개 등등.

**numbered list** 수정
\0. \1. \2. 이렇게 시작하면 넘버링을 수동으로 변경해야 합니다.
예를 들어 중간 번호 \1.에 다른 내용을 넣고 싶으면 기존 \1.을 \2.로 고치고 \3.을 넣어야 합니다.
마크다운에서 numbered list는 \0. \0. \0. 구성 하여도 알아서 번호가 부여 됩니다.
일단 제가 수정한 ```javascript.md``` 파일만 변경했습니다.

**code highlight** 수정
``` \`\`\` ... \`\`\` ``` -> ``` \`\`\`javascript \`\`\` ```로 변경했습니다.

### nodejs 문서를 추가하려 합니다.

```nodejs.md```라고 이름을 지었긴 했지만 적절한지는 모르겠습니다.
angular를 사용한 클라이언트 프로젝트의 경우 프레임워크의 영향으로 패러다임이 자연스럽게 완성됩니다.
하지만 node.js 프로젝트의 경우 너무 자유롭다 생각되어 관련 내용들을 넣었으면 합니다.

### javascript.md 내용 추가